### PR TITLE
Enhance method header generation to include location type

### DIFF
--- a/src/Linqraft.SourceGenerator/SelectExprInfo.cs
+++ b/src/Linqraft.SourceGenerator/SelectExprInfo.cs
@@ -34,6 +34,9 @@ internal abstract record SelectExprInfo
     // Get the namespace where DTOs will be placed
     protected abstract string GetDtoNamespace();
 
+    // Get expression type string (for documentation)
+    protected abstract string GetExprTypeString();
+
     // Get the full name for a nested DTO class (can be overridden for nested class support)
     protected virtual string GetNestedDtoFullName(string nestedClassName)
     {
@@ -130,17 +133,14 @@ internal abstract record SelectExprInfo
         return BitConverter.ToString(hash).Replace("-", "")[..8]; // Use first 8 characters
     }
 
-    protected string GenerateMethodHeaderPart(
-        string dtoName,
-        InterceptableLocation location,
-        string type
-    )
+    protected string GenerateMethodHeaderPart(string dtoName, InterceptableLocation location)
     {
+        var typeString = GetExprTypeString();
         var displayLocationRaw = location.GetDisplayLocation();
         var locationFileOnly = displayLocationRaw.Split(['/', '\\']).Last();
         return $"""
             /// <summary>
-            /// generated select expression method {dtoName} ({type}) <br/>
+            /// generated select expression method {dtoName} ({typeString}) <br/>
             /// at {locationFileOnly}
             /// </summary>
             {location.GetInterceptsLocationAttributeSyntax()}

--- a/src/Linqraft.SourceGenerator/SelectExprInfoAnonymous.cs
+++ b/src/Linqraft.SourceGenerator/SelectExprInfoAnonymous.cs
@@ -33,6 +33,9 @@ internal record SelectExprInfoAnonymous : SelectExprInfo
     // Anonymous types don't generate separate DTOs, but return caller namespace for consistency
     protected override string GetDtoNamespace() => CallerNamespace;
 
+    // Get expression type string (for documentation)
+    protected override string GetExprTypeString() => "anonymous";
+
     // Generate SelectExpr method
     protected override string GenerateSelectExprMethod(
         string dtoName,
@@ -45,7 +48,7 @@ internal record SelectExprInfoAnonymous : SelectExprInfo
         var sb = new StringBuilder();
 
         var id = GetUniqueId();
-        sb.AppendLine(GenerateMethodHeaderPart("anonymous type", location, "anonymous"));
+        sb.AppendLine(GenerateMethodHeaderPart("anonymous type", location));
         sb.AppendLine($"public static {returnTypePrefix}<TResult> SelectExpr_{id}<T, TResult>(");
         sb.AppendLine($"    this {returnTypePrefix}<T> query,");
         sb.AppendLine($"    Func<T, TResult> selector");

--- a/src/Linqraft.SourceGenerator/SelectExprInfoExplicitDto.cs
+++ b/src/Linqraft.SourceGenerator/SelectExprInfoExplicitDto.cs
@@ -119,6 +119,9 @@ internal record SelectExprInfoExplicitDto : SelectExprInfo
     // Get the namespace where DTOs will be placed
     protected override string GetDtoNamespace() => GetActualDtoNamespace();
 
+    // Get expression type string (for documentation)
+    protected override string GetExprTypeString() => "explicit";
+
     // Get the full name for a nested DTO class (including parent classes)
     protected override string GetNestedDtoFullName(string nestedClassName)
     {
@@ -169,7 +172,7 @@ internal record SelectExprInfoExplicitDto : SelectExprInfo
         var id = GetUniqueId();
         var methodDecl =
             $"public static {returnTypePrefix}<TResult> SelectExpr_{id}<TIn, TResult>(";
-        sb.AppendLine(GenerateMethodHeaderPart(dtoName, location, "explicit"));
+        sb.AppendLine(GenerateMethodHeaderPart(dtoName, location));
         sb.AppendLine($"{methodDecl}");
         sb.AppendLine($"    this {returnTypePrefix}<TIn> query,");
         sb.AppendLine($"    Func<TIn, object> selector) where TResult : {dtoFullName}");

--- a/src/Linqraft.SourceGenerator/SelectExprInfoNamed.cs
+++ b/src/Linqraft.SourceGenerator/SelectExprInfoNamed.cs
@@ -36,6 +36,9 @@ internal record SelectExprInfoNamed : SelectExprInfo
     protected override string GetDtoNamespace() =>
         SourceType.ContainingNamespace?.ToDisplayString() ?? CallerNamespace;
 
+    // Get expression type string (for documentation)
+    protected override string GetExprTypeString() => "predefined";
+
     protected override string GenerateSelectExprMethod(
         string dtoName,
         DtoStructure structure,
@@ -50,7 +53,7 @@ internal record SelectExprInfoNamed : SelectExprInfo
 
         var sb = new StringBuilder();
         var id = GetUniqueId();
-        sb.AppendLine(GenerateMethodHeaderPart(dtoName, location, "predefined"));
+        sb.AppendLine(GenerateMethodHeaderPart(dtoName, location));
         sb.AppendLine($"public static {returnTypePrefix}<TResult> SelectExpr_{id}<T, TResult>(");
         sb.AppendLine($"    this {returnTypePrefix}<T> query,");
         sb.AppendLine($"    Func<T, TResult> selector)");


### PR DESCRIPTION
Improve the method header generation by adding the location type to the SelectExpr records, providing clearer context in the generated documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated method header generation in the source generator to streamline how generated method documentation and attributes are produced.

* **Documentation**
  * Generated method summaries now include the expression type and show only the file portion of the location.
  * Expression types are indicated (e.g., anonymous, explicit, predefined) in generated docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->