### PR TITLE
Refactor AnalyzeAnonymousType to remove unused property accessibilities

### DIFF
--- a/src/Linqraft.Core/DtoStructure.cs
+++ b/src/Linqraft.Core/DtoStructure.cs
@@ -119,13 +119,11 @@ public record DtoStructure(ITypeSymbol SourceType, List<DtoProperty> Properties)
     /// <param name="anonymousObj">The anonymous object creation expression to analyze</param>
     /// <param name="semanticModel">The semantic model for type resolution</param>
     /// <param name="sourceType">The source type being selected from</param>
-    /// <param name="propertyAccessibilities">Optional dictionary mapping property names to accessibility modifiers</param>
     /// <returns>A DtoStructure representing the anonymous type</returns>
     public static DtoStructure? AnalyzeAnonymousType(
         AnonymousObjectCreationExpressionSyntax anonymousObj,
         SemanticModel semanticModel,
-        ITypeSymbol sourceType,
-        Dictionary<string, string>? propertyAccessibilities = null
+        ITypeSymbol sourceType
     )
     {
         // Get the type info of the anonymous object itself

--- a/src/Linqraft.Core/SelectExprInfoExplicitDto.cs
+++ b/src/Linqraft.Core/SelectExprInfoExplicitDto.cs
@@ -136,13 +136,7 @@ public record SelectExprInfoExplicitDto : SelectExprInfo
     /// </summary>
     protected override DtoStructure GenerateDtoStructure()
     {
-        var propertyAccessibilities = ExtractPropertyAccessibilities();
-        return DtoStructure.AnalyzeAnonymousType(
-            AnonymousObject,
-            SemanticModel,
-            SourceType,
-            propertyAccessibilities
-        )!;
+        return DtoStructure.AnalyzeAnonymousType(AnonymousObject, SemanticModel, SourceType)!;
     }
 
     /// <summary>


### PR DESCRIPTION
Simplify the `AnalyzeAnonymousType` method by removing the unused `propertyAccessibilities` parameter, streamlining the code and improving readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal API by removing an unused optional parameter from a core analysis method. Updated dependent code to use the streamlined method signature. No changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->